### PR TITLE
Do not crop gif transparency

### DIFF
--- a/src/Compressor.cs
+++ b/src/Compressor.cs
@@ -60,7 +60,7 @@ namespace MadsKristensen.ImageOptimizer
                 return string.Format(CultureInfo.CurrentCulture, "/c jpegtran -copy none -optimize -progressive \"{0}\" \"{1}\"", sourceFile, targetFile);
 
             case ".gif":
-                return string.Format(CultureInfo.CurrentCulture, "/c gifsicle --crop-transparency --no-comments --no-extensions --no-names --optimize=3 --batch \"{0}\" --output=\"{1}\"", sourceFile, targetFile);
+                return string.Format(CultureInfo.CurrentCulture, "/c gifsicle --no-comments --no-extensions --no-names --optimize=3 --batch \"{0}\" --output=\"{1}\"", sourceFile, targetFile);
             }
 
             return null;


### PR DESCRIPTION
I believe this is the fix for https://github.com/madskristensen/ImageOptimizer/issues/4
Gifsicle is cropping the transparent borders from the images and changing their size. 
